### PR TITLE
Modify the wrong chinese translation for C# Razor keywords

### DIFF
--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -651,7 +651,7 @@ Razor 關鍵字會使用 `@(Razor Keyword)` (例如 `@(functions)`) 逸出。
 
 ### <a name="c-razor-keywords"></a>C# Razor 關鍵字
 
-* 大小寫
+* case
 * do
 * default
 * for

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -663,7 +663,7 @@ Razor 關鍵字會使用 `@(Razor Keyword)` (例如 `@(functions)`) 逸出。
 * try
 * catch
 * finally
-* 使用
+* using
 * while
 
 C# Razor 關鍵字必須使用 `@(@C# Razor Keyword)` (例如 `@(@case)`) 雙重逸出。 第一個 `@` 會將 Razor 剖析器逸出。 第二個 `@` 會將 C# 剖析器逸出。


### PR DESCRIPTION
"大小寫" to "case"
"使用" to "using"